### PR TITLE
Fixed example link in Collections presentation

### DIFF
--- a/slides/9 Collections Generics/index.md
+++ b/slides/9 Collections Generics/index.md
@@ -539,7 +539,7 @@ int Compare(T x, T y)
 </div>
 
 <br />
-<a href="Example https://dotnetfiddle.net/RFNIVq">Example</a>
+<a href="https://dotnetfiddle.net/RFNIVq">Example</a>
 
 
 ***


### PR DESCRIPTION
Hey guys, nice presentations. There was one incorrect link as it had `Example` word in `href` before actual uri, so it didn't work and i fixed it.
