### PR TITLE
Nullable types - are always value types

### DIFF
--- a/slides/2 CSharp Essentials/index.html
+++ b/slides/2 CSharp Essentials/index.html
@@ -275,7 +275,7 @@ The same but with var:
 
 <p><strong>var</strong> is not allowed:</p>
 
-<table class="pre"><tr><td><pre lang="cs"><span class="k">public</span> <span class="k">class</span> SomeClass { <span class="k">var</span> _field <span class="o">=</span> <span class="k">new</span> List(); }
+<table class="pre"><tr><td><pre lang="cs"><span class="k">public</span> <span class="k">class</span> SomeClass { <span class="k">var</span> someField <span class="o">=</span> <span class="k">new</span> List(); }
 </pre></td></tr></table>
 
 </div>   
@@ -390,7 +390,7 @@ The same but with var:
 
 <ul>
 <li>are types that build over value types with <strong>null</strong> value added</li>
-<li>are always reference types</li>
+<li>are always value types</li>
 <li>could be created from value type only (including user-defined)</li>
 </ul>
 

--- a/slides/2 CSharp Essentials/index.md
+++ b/slides/2 CSharp Essentials/index.md
@@ -157,7 +157,7 @@ var var4 = b as IEnumerable;
 **var** is not allowed:
 
 ```cs
-public class SomeClass { var _field = new List(); }
+public class SomeClass { var someField = new List(); }
 ```
 </div>   
 
@@ -223,7 +223,7 @@ Reference could be null, which means no object in heap to reference
 ###Nullable types
 
 - are types that build over value types with **null** value added
-- are always reference types
+- are always value types
 - could be created from value type only (including user-defined)   
 
 Syntax:


### PR DESCRIPTION
Lecture 2 slide states that `Nullable<>` is reference type, but it is `struct` actually.
Also fixed styling for field name (remove underscore, transform to camelCase)
